### PR TITLE
Remove redundant ball styling causing issue in Firefox

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -61,7 +61,6 @@
 			setTimeout(function(){
 				self.eventText('Spawn!', 'red', spawnPoint.x - 20, spawnPoint.y - 20);
 				var mondral = new Mondral(spawnPoint, self);
-				mondral.el.css({'border-width':'10px'})
 				self.canvas.append(mondral.el);
 				self.entities.push(mondral);
 			}, 3000);

--- a/js/mondral.js
+++ b/js/mondral.js
@@ -9,7 +9,7 @@ function Mondral(spawnPoint, game) {
 	this.ySpeed = 2;
 	this.x = spawnPoint.x + this.width / 2;
 	this.y = spawnPoint.y + this.height / 2;
-	this.el = $('<div class="mondral"></div>').width(this.width).height(this.height).css({'border-color': this.color, 'left': spawnPoint.x, 'top': spawnPoint.y});
+	this.el = $('<div class="mondral"></div>').width(this.width).height(this.height).css({'left': spawnPoint.x, 'top': spawnPoint.y});
 	this.flat = false;
 	this.fallDist = 0;
 	this.overlapping = false;


### PR DESCRIPTION
Looks fine in Chrome, but Firefox renders a second larger ball.